### PR TITLE
add github action for automated build and deployment of docker files

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -1,0 +1,28 @@
+name: build_docker
+
+on:
+  # build on new v* tag push
+  push:
+    tags:
+      - v*
+  # allow manual trigger
+  workflow_dispatch:
+
+jobs:
+   build-and-publish:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+    - name: checkout source
+      uses: actions/checkout@v2
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - name: build and publish
+      uses: VaultVulp/gp-docker-action@1.1.7
+      with:
+        build-context: ./server
+        dockerfile: ./server/Dockerfile
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        image-name: blockchain-adapter
+        image-tag: ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
This will add automated docker builds via github actions to the github registry.

Please do not merge until we manage to enable github actions on the GSMA account.
Once available the registry feature has to be enabled (see https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/enabling-improved-container-support)