### PR TITLE
expose get signature payloadlink and integrate test

### DIFF
--- a/api/doc/Apis/ContractApi.md
+++ b/api/doc/Apis/ContractApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**fetchPrivateDocument**](ContractApi.md#fetchPrivateDocument) | **GET** /private-documents/{referenceID} | 
 [**fetchPrivateDocumentReferenceIDs**](ContractApi.md#fetchPrivateDocumentReferenceIDs) | **GET** /private-documents | 
 [**fetchSignatures**](ContractApi.md#fetchSignatures) | **GET** /signatures/{referenceID}/{signerMSP} | 
+[**getReferencePayloadLink**](ContractApi.md#getReferencePayloadLink) | **GET** /payloadlink/{referenceID}/{creatorMSPID} | 
 [**uploadPrivateDocument**](ContractApi.md#uploadPrivateDocument) | **POST** /private-documents | 
 [**uploadSignature**](ContractApi.md#uploadSignature) | **PUT** /signatures/{referenceID} | 
 [**verifySignatures**](ContractApi.md#verifySignatures) | **GET** /signatures/{referenceID}/verify/{creator}/{signer} | 
@@ -105,6 +106,34 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **referenceID** | **String**| The referenceID of the document | [default to null]
  **signerMSP** | **String**| The signers MSP name | [default to null]
+
+### Return type
+
+[**String**](../Models/string.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain, application/json
+
+<a name="getReferencePayloadLink"></a>
+# **getReferencePayloadLink**
+> String getReferencePayloadLink(referenceID, creatorMSPID)
+
+
+
+    Fetch the stored referencepayloadlink for a given reference id and creator
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **referenceID** | **String**| The referenceID | [default to null]
+ **creatorMSPID** | **String**| The initial creator MSPID of the contract. | [default to null]
 
 ### Return type
 

--- a/api/doc/README.md
+++ b/api/doc/README.md
@@ -14,6 +14,7 @@ Class | Method | HTTP request | Description
 *ContractApi* | [**fetchPrivateDocument**](Apis/ContractApi.md#fetchprivatedocument) | **GET** /private-documents/{referenceID} | Fetch a private document from the database, identified by its referenceID
 *ContractApi* | [**fetchPrivateDocumentReferenceIDs**](Apis/ContractApi.md#fetchprivatedocumentreferenceids) | **GET** /private-documents | show all private documents that are in the transient storage
 *ContractApi* | [**fetchSignatures**](Apis/ContractApi.md#fetchsignatures) | **GET** /signatures/{referenceID}/{signerMSP} | Fetch all signatures for a given referenceID and a signerMSP from the ledger
+*ContractApi* | [**getReferencePayloadLink**](Apis/ContractApi.md#getreferencepayloadlink) | **GET** /payloadlink/{referenceID}/{creatorMSPID} | Fetch the stored referencepayloadlink for a given reference id and creator
 *ContractApi* | [**uploadPrivateDocument**](Apis/ContractApi.md#uploadprivatedocument) | **POST** /private-documents | Upload a private document, shared between our own organization and a partner MSP
 *ContractApi* | [**uploadSignature**](Apis/ContractApi.md#uploadsignature) | **PUT** /signatures/{referenceID} | store a signature for the document identified by its referenceID on the ledger
 *ContractApi* | [**verifySignatures**](Apis/ContractApi.md#verifysignatures) | **GET** /signatures/{referenceID}/verify/{creator}/{signer} | Fetch all signatures for a given reference id, creator and signer from the ledger and verify the content against the on chain referencepayload link

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Blockchain-Adapter
   description: This is the REST api specification for the blockchain-adapter
-  version: 0.1.1
+  version: 0.1.2
   contact:
     name: Simon Schulz
     email: Simon.Schulz01@telekom.de
@@ -342,6 +342,39 @@ paths:
       responses:
         '200':
           description: Successful operation, returns json of verified signatures
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: models/ErrorCode.yaml
+  /payloadlink/{referenceID}/{creatorMSPID}:
+    get:
+      description: Fetch the stored referencepayloadlink for a given reference id and creator
+      tags:
+        - contract
+      parameters:
+        - in: path
+          name: referenceID
+          required: true
+          schema:
+            type: string
+          description: The referenceID
+        - in: path
+          name: creatorMSPID
+          required: true
+          schema:
+            type: string
+          description: The initial creator MSPID of the contract.
+      operationId: getReferencePayloadLink
+      responses:
+        '200':
+          description: Successful operation, returns the referencepayloadlink
           content:
             text/plain:
               schema:

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
     name: Simon Schulz
   description: This is the REST api specification for the blockchain-adapter
   title: Blockchain-Adapter
-  version: 0.1.1
+  version: 0.1.2
 servers:
 - url: /
 tags:
@@ -395,6 +395,45 @@ paths:
                 type: string
                 x-content-type: text/plain
           description: Successful operation, returns json of verified signatures
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorCode'
+          description: Internal Error
+      tags:
+      - contract
+      x-eov-operation-handler: controllers/ContractController
+  /payloadlink/{referenceID}/{creatorMSPID}:
+    get:
+      description: Fetch the stored referencepayloadlink for a given reference id
+        and creator
+      operationId: getReferencePayloadLink
+      parameters:
+      - description: The referenceID
+        explode: false
+        in: path
+        name: referenceID
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The initial creator MSPID of the contract.
+        explode: false
+        in: path
+        name: creatorMSPID
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+          description: Successful operation, returns the referencepayloadlink
         "500":
           content:
             application/json:

--- a/server/controllers/ContractController.js
+++ b/server/controllers/ContractController.js
@@ -24,6 +24,10 @@ const fetchSignatures = async (request, response) => {
   await Controller.handleRequest(request, response, service.fetchSignatures);
 };
 
+const getReferencePayloadLink = async (request, response) => {
+  await Controller.handleRequest(request, response, service.getReferencePayloadLink);
+};
+
 const uploadPrivateDocument = async (request, response) => {
   await Controller.handleRequest(request, response, service.uploadPrivateDocument);
 };
@@ -42,6 +46,7 @@ module.exports = {
   fetchPrivateDocument,
   fetchPrivateDocumentReferenceIDs,
   fetchSignatures,
+  getReferencePayloadLink,
   uploadPrivateDocument,
   uploadSignature,
   verifySignatures,

--- a/server/hyperledger/blockchain_service.js
+++ b/server/hyperledger/blockchain_service.js
@@ -669,6 +669,38 @@ class BlockchainService {
       return Promise.reject(new ErrorCode('ERROR_INTERNAL', 'getBlockchainStatus() failed'));
     });
   }
+
+
+  /** get a reference payloadlink from the ledger
+   * @param {referenceId} referenceId - a reference Id
+   * @param {creatorMSPID} creatorMSPID - the initial creator
+   * @return {Promise} referencepayload link
+  */
+  getReferencePayloadLink(referenceId, creatorMSPID) {
+    const self = this;
+
+    return this.network.then( (network) => {
+    // fetch contract
+      const contract = network.getContract(self.connectionProfile.config.contractID);
+
+      console.log('> fetching referencepayloadlink for referenceId ' + referenceId);
+
+      // enable filter to execute query on our MSP
+      const onMSP = this.connectionProfile.organizations[this.connectionProfile.client.organization].mspid;
+      network.queryHandler.setFilter(onMSP);
+
+      return contract.evaluateTransaction('GetReferencePayloadLink', ...[creatorMSPID, referenceId]).then( (payloadlink) => {
+        // reset filter
+        network.queryHandler.setFilter('');
+
+        console.log('> got payloadlink: ' + payloadlink.toString());
+
+        return payloadlink.toString();
+      }).catch( (error) => {
+        return Promise.reject(ErrorCode.fromError(error, 'GetReferencePayloadLink() failed'));
+      });
+    });
+  }
 }
 
 module.exports = {BlockchainService};

--- a/server/services/ContractService.js
+++ b/server/services/ContractService.js
@@ -151,6 +151,26 @@ const verifySignatures = ({referenceID, creator, signer}) => new Promise(
     },
 );
 
+/** Fetch the stored referencepayloadlink for a given reference id and creator
+ * @param {string} referenceID - the referenceID
+ * @param {string} creatorMSPID - the initial creator of the contract.
+ * @return {string}
+*/
+const getReferencePayloadLink = ({referenceID, creatorMSPID}) => new Promise(
+    async (resolve, reject) => {
+      const blockchainConnection = new BlockchainService(process.env.BSA_CCP);
+
+      blockchainConnection.getReferencePayloadLink(referenceID, creatorMSPID)
+          .then( (response) => {
+            resolve(Service.successResponse(response, 200));
+          }).catch((error) => {
+            reject(Service.rejectResponse({'code': error.code, 'message': error.message}, 500));
+          }).finally( () => {
+            blockchainConnection.disconnect();
+          });
+    },
+);
+
 module.exports = {
   fetchPrivateDocument,
   deletePrivateDocument,
@@ -159,4 +179,5 @@ module.exports = {
   uploadPrivateDocument,
   uploadSignature,
   verifySignatures,
+  getReferencePayloadLink,
 };

--- a/test_query.sh
+++ b/test_query.sh
@@ -141,7 +141,16 @@ RES=$(request "PUT" '{"algorithm": "secp384r1", "certificate" : "'"${CERT}"'", "
 TXID_TMUS=$(echo $RES | jq -r .txID)
 echo "> stored signature with txid $TXID_TMUS"
 
-
+echo "###################################################"
+echo "> verifying reference payload link for creator "
+RES=$(request "GET" '' http://$BSA_DTAG/payloadlink/$REFERENCE_ID/DTAG)
+if [ $RES == "$PAYLOADLINK" ]; then
+    echo "> ok. payloadlink on ledger matches local one!"
+else
+    echo "FAILED, expected: $PAYLOADLINK"
+    echo "received        : $RES"
+    exit 1
+fi
 
 echo "###################################################"
 echo "> test get all signatures call on dtag: signed by TMUS "


### PR DESCRIPTION
This PR adds  ``GET http://..../payloadlink/<REFERENCE_ID>/<MSP>`` which returns the matching payloadlink.

Documentation: https://github.com/GSMA-CPAS/BWRP-blockchain-adapter/blob/ssch-referencepayloadlink/api/doc/Apis/ContractApi.md#getreferencepayloadlink 

This also adds a test case to test_query.sh