### PR TITLE
add proper content type to all responses

### DIFF
--- a/api/doc/Apis/ContractApi.md
+++ b/api/doc/Apis/ContractApi.md
@@ -176,7 +176,7 @@ No authorization required
 
 <a name="verifySignatures"></a>
 # **verifySignatures**
-> String verifySignatures(referenceID, creator, signer)
+> Object verifySignatures(referenceID, creator, signer)
 
 
 
@@ -192,7 +192,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**String**](../Models/string.md)
+[**Object**](../Models/object.md)
 
 ### Authorization
 

--- a/api/doc/Apis/DiscoveryApi.md
+++ b/api/doc/Apis/DiscoveryApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 
 <a name="getDiscoveryMSP"></a>
 # **getDiscoveryMSP**
-> String getDiscoveryMSP(mspid)
+> Object getDiscoveryMSP(mspid)
 
 
 
@@ -24,7 +24,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**String**](../Models/string.md)
+[**Object**](../Models/object.md)
 
 ### Authorization
 
@@ -37,7 +37,7 @@ No authorization required
 
 <a name="getDiscoveryMSPs"></a>
 # **getDiscoveryMSPs**
-> String getDiscoveryMSPs()
+> Object getDiscoveryMSPs()
 
 
 
@@ -48,7 +48,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**String**](../Models/string.md)
+[**Object**](../Models/object.md)
 
 ### Authorization
 

--- a/api/doc/Apis/StatusApi.md
+++ b/api/doc/Apis/StatusApi.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 <a name="getApiStatus"></a>
 # **getApiStatus**
-> String getApiStatus()
+> Object getApiStatus()
 
 
 
@@ -20,7 +20,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**String**](../Models/string.md)
+[**Object**](../Models/object.md)
 
 ### Authorization
 

--- a/api/doc/Apis/WebhookApi.md
+++ b/api/doc/Apis/WebhookApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 
 <a name="webhooksGet"></a>
 # **webhooksGet**
-> String webhooksGet()
+> Object webhooksGet()
 
 
 
@@ -22,7 +22,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**String**](../Models/string.md)
+[**Object**](../Models/object.md)
 
 ### Authorization
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Blockchain-Adapter
   description: This is the REST api specification for the blockchain-adapter
-  version: 0.1.1
+  version: 0.1.2
   contact:
     name: Simon Schulz
     email: Simon.Schulz01@telekom.de
@@ -30,8 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
         '500':
           description: Internal Error
           content: {}
@@ -54,8 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
         '500':
           description: Internal Error
           content: {}
@@ -71,8 +69,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
         '500':
           description: Internal Error
           content: {}
@@ -242,8 +239,7 @@ paths:
           content: 
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
         '500':
           description: Internal Server Error
           content: {}
@@ -307,7 +303,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
         '500':
           description: Internal Error
           content:
@@ -345,8 +340,7 @@ paths:
           content:
             text/plain:
               schema:
-                type: string
-                x-content-type: text/plain
+                type: object
         '500':
           description: Internal Error
           content:
@@ -373,7 +367,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
         '500':
           description: Internal Error
           content:
@@ -424,7 +417,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
         '500':
           description: Internal Error
           content:

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
     name: Simon Schulz
   description: This is the REST api specification for the blockchain-adapter
   title: Blockchain-Adapter
-  version: 0.1.1
+  version: 0.1.2
 servers:
 - url: /
 tags:
@@ -29,8 +29,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
           description: A list of all discovered MSPs
         "500":
           content: {}
@@ -56,8 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
           description: Details about the requested MSP
         "500":
           content: {}
@@ -74,8 +72,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
           description: The status of the service
         "500":
           content: {}
@@ -269,8 +266,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-                x-content-type: application/json
+                type: object
           description: List of Subscriptions
         "500":
           content: {}
@@ -344,7 +340,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
           description: Successful operation, returns json of signatures
         "500":
           content:
@@ -392,8 +387,7 @@ paths:
           content:
             text/plain:
               schema:
-                type: string
-                x-content-type: text/plain
+                type: object
           description: Successful operation, returns json of verified signatures
         "500":
           content:
@@ -440,7 +434,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
           description: Successful operation, returns transaction hash
         "500":
           content:
@@ -474,7 +467,6 @@ paths:
             text/plain:
               schema:
                 type: string
-                x-content-type: text/plain
           description: Successful operation
         "500":
           content:

--- a/server/services/DiscoveryService.js
+++ b/server/services/DiscoveryService.js
@@ -13,7 +13,7 @@ const getDiscoveryMSP = ({mspid}) => new Promise(
 
       blockchainConnection.getDiscoveryMSP(mspid)
           .then( (results) => {
-            resolve(Service.successResponse(JSON.stringify(results), 200));
+            resolve(Service.successResponse(results, 200));
           }).catch((error) => {
             reject(Service.rejectResponse({'code': error.code, 'message': error.message}, 500));
           }).finally( () => {
@@ -31,7 +31,7 @@ const getDiscoveryMSPs = () => new Promise(
 
       blockchainConnection.getDiscoveryMSPs()
           .then( (results) => {
-            resolve(Service.successResponse(JSON.stringify(results), 200));
+            resolve(Service.successResponse(results, 200));
           }).catch((error) => {
             reject(Service.rejectResponse({'code': error.code, 'message': error.message}, 500));
           }).finally( () => {

--- a/server/services/StatusService.js
+++ b/server/services/StatusService.js
@@ -28,7 +28,7 @@ const getApiStatus = () => new Promise(
 
       return blockchainConnection.getBlockchainStatus().then((blockchainStatus) => {
         statusInfo.hyperledger = blockchainStatus;
-        resolve(Service.successResponse(JSON.stringify(statusInfo)));
+        resolve(Service.successResponse(statusInfo));
       }).catch( (error) => {
         reject(Service.rejectResponse({'code': error.code, 'message': error.message}, 500));
       });

--- a/server/services/WebhookService.js
+++ b/server/services/WebhookService.js
@@ -97,7 +97,7 @@ const webhooksGET = () => new Promise(
     async (resolve, reject) => {
       try {
         const subscriptions = webhookService.getSubscriptions();
-        resolve(Service.successResponse(JSON.stringify(subscriptions), 200));
+        resolve(Service.successResponse(subscriptions, 200));
       } catch (error) {
         reject(Service.rejectResponse({'message': error.toString()}, 500));
       }


### PR DESCRIPTION
this resolves https://github.com/GSMA-CPAS/BWRP-blockchain-adapter/issues/23

Add the proper content type to all requests by calling resolve with the object instead of JSON.stringify(obj) 
This makes sure express can automatically chose the proper content type.

Additionally i removed the unnecessary (and unused) x-content-type entries in the api json as openapi ignores them.