### PR TITLE
Use updated signature string in test script

### DIFF
--- a/test_query.sh
+++ b/test_query.sh
@@ -132,7 +132,7 @@ SIGNATUREPAYLOAD=$(payload "DTAG" "$REFERENCE_ID" "$PAYLOADLINK")
 echo -e "payload to sign <$SIGNATUREPAYLOAD>"
 SIGNATURE_DTAG=$(echo -ne $SIGNATUREPAYLOAD | openssl dgst -sha256 -sign $DIR/user.DTAG.key | openssl base64 | tr -d '\n')
 # call blockchain adapter
-RES=$(request "PUT" '{"algorithm": "secp384r1", "certificate" : "'"${CERT}"'", "signature" : "'$SIGNATURE_DTAG'" }'  http://$BSA_DTAG/signatures/$REFERENCE_ID)
+RES=$(request "PUT" '{"algorithm": "ecdsaWithSha256", "certificate" : "'"${CERT}"'", "signature" : "'$SIGNATURE_DTAG'" }'  http://$BSA_DTAG/signatures/$REFERENCE_ID)
 TXID_DTAG=$(echo $RES | jq -r .txID)
 echo "> stored signature with txid $TXID_DTAG"
 
@@ -146,7 +146,7 @@ echo -e "payload to sign <$SIGNATUREPAYLOAD>"
 SIGNATURE_TMUS=$(echo -ne $SIGNATUREPAYLOAD | openssl dgst -sha256 -sign $DIR/user.TMUS.key | openssl base64 | tr -d '\n')
 
 # call blockchain adapter
-RES=$(request "PUT" '{"algorithm": "secp384r1", "certificate" : "'"${CERT}"'", "signature" : "'$SIGNATURE_TMUS'" }'  http://$BSA_TMUS/signatures/$REFERENCE_ID)
+RES=$(request "PUT" '{"algorithm": "ecdsaWithSha256", "certificate" : "'"${CERT}"'", "signature" : "'$SIGNATURE_TMUS'" }'  http://$BSA_TMUS/signatures/$REFERENCE_ID)
 TXID_TMUS=$(echo $RES | jq -r .txID)
 echo "> stored signature with txid $TXID_TMUS"
 


### PR DESCRIPTION
Minor fix to change the signature algorithm string to the defined string in the the wiki: https://github.com/GSMA-CPAS/BWRP/wiki/Signatures

The fix only affects the test script. It also doesn't break anything, as the string isn't used in the chaincode's current main branch.

Should work with the following chaincode PR: https://github.com/GSMA-CPAS/BWRP-chaincode/pull/38