### PR TITLE
add test cases for "CanSignDocument" extended attribute

### DIFF
--- a/test_query.sh
+++ b/test_query.sh
@@ -111,9 +111,9 @@ echo "###################################################"
 echo "> creating root and user certs"
 echo "###################################################"
 createRoot DTAG
-createUserCert DTAG '{"attrs":{"CanSignDocument":"yes"}}'
+createUserCert DTAG
 createRoot TMUS
-createUserCert TMUS '{"attrs":{"CanSignDocument":"yes"}}'
+createUserCert TMUS
 
 
 echo "###################################################"


### PR DESCRIPTION
see https://github.com/GSMA-CPAS/BWRP-chaincode/pull/51
this PR adds a similar test case to the blockchainadapter